### PR TITLE
fix: hit area calculation

### DIFF
--- a/packages/vue-split-panel/playground/src/App.vue
+++ b/packages/vue-split-panel/playground/src/App.vue
@@ -3,27 +3,21 @@ import { SplitPanel } from '../../src';
 </script>
 
 <template>
-	<SplitPanel id="panels-root">
+	<SplitPanel id="panels-root" divider-hit-area="50px" orientation="vertical">
 		<template #start>
 			<div id="a" class="panel">
 				Panel A
 			</div>
 		</template>
 
-		<template #end>
-			<SplitPanel id="panels-nested" orientation="vertical">
-				<template #start>
-					<div id="b" class="panel">
-						Panel B
-					</div>
-				</template>
+		<template #divider>
+			<div class="divider" />
+		</template>
 
-				<template #end>
-					<div id="c" class="panel">
-						Panel C
-					</div>
-				</template>
-			</SplitPanel>
+		<template #end>
+			<div id="b" class="panel">
+				Panel B
+			</div>
 		</template>
 	</SplitPanel>
 </template>
@@ -57,5 +51,11 @@ import { SplitPanel } from '../../src';
 
 #b {
 	background: skyblue;
+}
+
+.divider {
+	height: 12px;
+	background-color: black;
+	width: 100%;
 }
 </style>

--- a/packages/vue-split-panel/src/SplitPanel.vue
+++ b/packages/vue-split-panel/src/SplitPanel.vue
@@ -320,7 +320,7 @@ defineExpose({ collapse, expand, toggle });
 
 		&.horizontal {
 			block-size: 100%;
-			inline-size: 0;
+			inline-size: max-content;
 
 			& :deep(> :first-child)::after {
 				block-size: 100%;
@@ -333,7 +333,7 @@ defineExpose({ collapse, expand, toggle });
 
 		&.vertical {
 			inline-size: 100%;
-			block-size: 0;
+			block-size: max-content;
 
 			& :deep(> :first-child)::after {
 				inline-size: 100%;


### PR DESCRIPTION
`useElementSize` captured the size as `0` as the parent div wasn't matching the content size of the slotted child

Fixes #1