### PR TITLE
fix: add z-index property to the divider element to establish proper stacking order

### DIFF
--- a/packages/vue-split-panel/src/SplitPanel.vue
+++ b/packages/vue-split-panel/src/SplitPanel.vue
@@ -339,6 +339,7 @@ defineExpose({ collapse, expand, toggle });
 
 .divider {
 	position: relative;
+	z-index: +1;
 
 	&:not(.disabled) {
 		& :deep(> :first-child) {

--- a/packages/vue-split-panel/src/SplitPanel.vue
+++ b/packages/vue-split-panel/src/SplitPanel.vue
@@ -339,7 +339,7 @@ defineExpose({ collapse, expand, toggle });
 
 .divider {
 	position: relative;
-	z-index: +1;
+	z-index: 1;
 
 	&:not(.disabled) {
 		& :deep(> :first-child) {


### PR DESCRIPTION
Allow the divider hit box to render on top of the panel contents