### PR TITLE
chore: update peer dependency for Vue to ^3.5.0

### DIFF
--- a/packages/vue-split-panel/package.json
+++ b/packages/vue-split-panel/package.json
@@ -45,7 +45,7 @@
 		"lint:fix": "pnpm run lint --fix"
 	},
 	"peerDependencies": {
-		"vue": "^3.0.0"
+		"vue": "^3.5.0"
 	},
 	"dependencies": {
 		"@vueuse/core": "13.7.0",


### PR DESCRIPTION
`useTemplateRef ` is introduced from `3.5+`. So we should consider update `Vue` version in `peerDependencies`.

<img width="2880" height="1556" alt="image" src="https://github.com/user-attachments/assets/02e74825-0253-4b1b-bdc5-2874b0ffa80d" />
