### PR TITLE
chore: ensure '@vueuse/core' is not externalized in tsdown configuration

### DIFF
--- a/packages/vue-split-panel/tsdown.config.ts
+++ b/packages/vue-split-panel/tsdown.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'tsdown';
 export default defineConfig([
 	{
 		entry: ['./src/index.ts'],
+		noExternal: ['@vueuse/core'],
 		platform: 'browser',
 		fromVite: true,
 		dts: {


### PR DESCRIPTION
Hi, @rijkvanzanten. I try to run `pnpm build` and notice that all imports from `@vueuse/core` is externalized.

<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/81bcc9bc-ed78-4d6b-b972-bc0d2aaf5b40" />

I think we should add it to `peerDependencies` or bundle it in dist. For me, the second choice is best. Maybe some developers don't tend to use this library. We should consider avoiding forcing developers to be limited to a specific library.

You can check the result of incuding `@vueuse/core`

<img width="2880" height="1798" alt="image" src="https://github.com/user-attachments/assets/345c8846-3dd2-47db-8709-b52038ff73db" />

If you don't think so, just feel free to close this pr. Thanks very much.
