### PR TITLE
refactor: move component logic to composables

### DIFF
--- a/packages/vue-split-panel/src/composables/use-grid-template.ts
+++ b/packages/vue-split-panel/src/composables/use-grid-template.ts
@@ -1,0 +1,51 @@
+import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
+import type { Direction, Orientation, Primary } from '../types';
+import { computed, toValue } from 'vue';
+
+export interface UseGridTemplateOptions {
+	collapsed: Ref<boolean>;
+	minSizePercentage: ComputedRef<number | undefined>;
+	maxSizePercentage: ComputedRef<number | undefined>;
+	sizePercentage: ComputedRef<number>;
+	dividerSize: ComputedRef<number>;
+	primary: MaybeRefOrGetter<Primary | undefined>;
+	direction: MaybeRefOrGetter<Direction>;
+	orientation: MaybeRefOrGetter<Orientation>;
+}
+
+export const useGridTemplate = (options: UseGridTemplateOptions) => {
+	const gridTemplate = computed(() => {
+		let primary: string;
+
+		if (options.collapsed.value) {
+			primary = '0';
+		}
+		else if (options.minSizePercentage.value !== undefined && options.maxSizePercentage.value !== undefined) {
+			primary = `clamp(0%, clamp(${options.minSizePercentage.value}%, ${options.sizePercentage.value}%, ${options.maxSizePercentage.value}%), calc(100% - ${options.dividerSize.value}px))`;
+		}
+		else {
+			primary = `clamp(0%, ${options.sizePercentage.value}%, calc(100% - ${options.dividerSize.value}px))`;
+		}
+
+		const secondary = 'auto';
+
+		if (!toValue(options.primary) || toValue(options.primary) === 'start') {
+			if (toValue(options.direction) === 'ltr' || toValue(options.orientation) === 'vertical') {
+				return `${primary} ${options.dividerSize.value}px ${secondary}`;
+			}
+			else {
+				return `${secondary} ${options.dividerSize.value}px ${primary}`;
+			}
+		}
+		else {
+			if (toValue(options.direction) === 'ltr' || toValue(options.orientation) === 'vertical') {
+				return `${secondary} ${options.dividerSize.value}px ${primary}`;
+			}
+			else {
+				return `${primary} ${options.dividerSize.value}px ${secondary}`;
+			}
+		}
+	});
+
+	return { gridTemplate };
+};

--- a/packages/vue-split-panel/src/composables/use-keyboard.ts
+++ b/packages/vue-split-panel/src/composables/use-keyboard.ts
@@ -1,0 +1,55 @@
+import type { MaybeRefOrGetter, Ref } from 'vue';
+import type { Orientation, Primary } from '../types';
+import { clamp } from '@vueuse/core';
+import { toValue } from 'vue';
+
+export interface UseKeyboardOptions {
+	disabled: MaybeRefOrGetter<boolean>;
+	collapsible: MaybeRefOrGetter<boolean>;
+	primary: MaybeRefOrGetter<Primary | undefined>;
+	orientation: MaybeRefOrGetter<Orientation>;
+}
+
+export const useKeyboard = (sizePercentage: Ref<number>, collapsed: Ref<boolean>, options: UseKeyboardOptions) => {
+	const handleKeydown = (event: KeyboardEvent) => {
+		if (toValue(options.disabled)) return;
+
+		if (['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Home', 'End', 'Enter'].includes(event.key)) {
+			event.preventDefault();
+
+			let newPosition = sizePercentage.value;
+
+			const increment = (event.shiftKey ? 10 : 1) * (toValue(options.primary) === 'end' ? -1 : 1);
+
+			if (
+				(event.key === 'ArrowLeft' && toValue(options.orientation) === 'horizontal')
+				|| (event.key === 'ArrowUp' && toValue(options.orientation) === 'vertical')
+			) {
+				newPosition -= increment;
+			}
+
+			if (
+				(event.key === 'ArrowRight' && toValue(options.orientation) === 'horizontal')
+				|| (event.key === 'ArrowDown' && toValue(options.orientation) === 'vertical')
+			) {
+				newPosition += increment;
+			}
+
+			if (event.key === 'Home') {
+				newPosition = toValue(options.primary) === 'end' ? 100 : 0;
+			}
+
+			if (event.key === 'End') {
+				newPosition = toValue(options.primary) === 'end' ? 0 : 100;
+			}
+
+			if (event.key === 'Enter' && toValue(options.collapsible)) {
+				collapsed.value = !collapsed.value;
+			}
+
+			sizePercentage.value = clamp(newPosition, 0, 100);
+		}
+	};
+
+	return { handleKeydown };
+};

--- a/packages/vue-split-panel/src/composables/use-pointer.ts
+++ b/packages/vue-split-panel/src/composables/use-pointer.ts
@@ -1,0 +1,81 @@
+import type { MaybeRefOrGetter } from '@vueuse/core';
+import type { ComputedRef, Ref } from 'vue';
+import type { Direction, Orientation, Primary } from '../types';
+import { clamp, useDraggable } from '@vueuse/core';
+import { toValue, watch } from 'vue';
+import { closestNumber } from '../utils/closest-number';
+import { pixelsToPercentage } from '../utils/pixels-to-percentage';
+
+export interface UsePointerOptions {
+	disabled: MaybeRefOrGetter<boolean>;
+	collapsible: MaybeRefOrGetter<boolean>;
+	primary: MaybeRefOrGetter<Primary | undefined>;
+	orientation: MaybeRefOrGetter<Orientation>;
+	direction: MaybeRefOrGetter<Direction>;
+	collapseThreshold: MaybeRefOrGetter<number | undefined>;
+	snapThreshold: MaybeRefOrGetter<number>;
+	dividerEl: MaybeRefOrGetter<HTMLElement | null>;
+	panelEl: MaybeRefOrGetter<HTMLElement | null>;
+	componentSize: ComputedRef<number>;
+	minSizePixels: ComputedRef<number | undefined>;
+	snapPixels: ComputedRef<number[]>;
+}
+
+export const usePointer = (collapsed: Ref<boolean>, sizePercentage: Ref<number>, sizePixels: Ref<number>, options: UsePointerOptions) => {
+	const { x: dividerX, y: dividerY, isDragging } = useDraggable(options.dividerEl, { containerElement: options.panelEl });
+
+	let hasToggledDuringCurrentDrag = false;
+
+	watch([dividerX, dividerY], ([newX, newY]) => {
+		if (toValue(options.disabled)) return;
+
+		let newPositionInPixels = toValue(options.orientation) === 'horizontal' ? newX : newY;
+
+		if (toValue(options.primary) === 'end') {
+			newPositionInPixels = options.componentSize.value - newPositionInPixels;
+		}
+
+		if (toValue(options.collapsible) && options.minSizePixels.value !== undefined && toValue(options.collapseThreshold) !== undefined && hasToggledDuringCurrentDrag === false) {
+			const collapseThreshold = options.minSizePixels.value - (toValue(options.collapseThreshold) ?? 0);
+			const expandThreshold = (toValue(options.collapseThreshold) ?? 0);
+
+			if (newPositionInPixels < collapseThreshold && collapsed.value === false) {
+				collapsed.value = true;
+				hasToggledDuringCurrentDrag = true;
+			}
+			else if (newPositionInPixels > expandThreshold && collapsed.value === true) {
+				collapsed.value = false;
+				hasToggledDuringCurrentDrag = true;
+			}
+		}
+
+		for (let snapPoint of options.snapPixels.value) {
+			if (toValue(options.direction) === 'rtl' && toValue(options.orientation) === 'horizontal') {
+				snapPoint = options.componentSize.value - snapPoint;
+			}
+
+			if (
+				newPositionInPixels >= snapPoint - toValue(options.snapThreshold)
+				&& newPositionInPixels <= snapPoint + toValue(options.snapThreshold)
+			) {
+				newPositionInPixels = snapPoint;
+			}
+		}
+
+		sizePercentage.value = clamp(pixelsToPercentage(options.componentSize.value, newPositionInPixels), 0, 100);
+	});
+
+	watch(isDragging, (newDragging) => {
+		if (newDragging === false) hasToggledDuringCurrentDrag = false;
+	});
+
+	const handleDblClick = () => {
+		const closest = closestNumber(options.snapPixels.value, sizePixels.value);
+
+		if (closest !== undefined) {
+			sizePixels.value = closest;
+		}
+	};
+
+	return { handleDblClick, isDragging };
+};

--- a/packages/vue-split-panel/src/composables/use-resize.ts
+++ b/packages/vue-split-panel/src/composables/use-resize.ts
@@ -1,0 +1,35 @@
+import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
+import type { Orientation, Primary } from '../types';
+import { useResizeObserver } from '@vueuse/core';
+import { onMounted, toValue, watch } from 'vue';
+import { pixelsToPercentage } from '../utils/pixels-to-percentage';
+
+export interface UseResizeOptions {
+	sizePixels: ComputedRef<number>;
+	panelEl: MaybeRefOrGetter<HTMLElement | null>;
+	orientation: MaybeRefOrGetter<Orientation>;
+	primary: MaybeRefOrGetter<Primary | undefined>;
+}
+
+export const useResize = (sizePercentage: Ref<number>, options: UseResizeOptions) => {
+	let cachedSizePixels = 0;
+
+	onMounted(() => {
+		cachedSizePixels = options.sizePixels.value;
+	});
+
+	watch(options.sizePixels, (newPixels, oldPixels) => {
+		if (newPixels === oldPixels) return;
+		cachedSizePixels = newPixels;
+	});
+
+	useResizeObserver(options.panelEl, (entries) => {
+		const entry = entries[0];
+		const { width, height } = entry.contentRect;
+		const size = toValue(options.orientation) === 'horizontal' ? width : height;
+
+		if (toValue(options.primary)) {
+			sizePercentage.value = pixelsToPercentage(size, cachedSizePixels);
+		}
+	});
+};

--- a/packages/vue-split-panel/src/composables/use-sizes.ts
+++ b/packages/vue-split-panel/src/composables/use-sizes.ts
@@ -1,0 +1,95 @@
+import type { MaybeComputedElementRef } from '@vueuse/core';
+import type { MaybeRefOrGetter, Ref } from 'vue';
+import type { Orientation, Primary, SizeUnit } from '../types';
+import { useElementSize } from '@vueuse/core';
+import { computed, toValue } from 'vue';
+import { percentageToPixels } from '../utils/percentage-to-pixels';
+import { pixelsToPercentage } from '../utils/pixels-to-percentage';
+
+export interface UseSizesOptions {
+	disabled: MaybeRefOrGetter<boolean>;
+	collapsible: MaybeRefOrGetter<boolean>;
+	primary: MaybeRefOrGetter<Primary | undefined>;
+	orientation: MaybeRefOrGetter<Orientation>;
+	sizeUnit: MaybeRefOrGetter<SizeUnit>;
+	minSize: MaybeRefOrGetter<number>;
+	maxSize: MaybeRefOrGetter<number | undefined>;
+	snapPoints: MaybeRefOrGetter<number[]>;
+	panelEl: MaybeComputedElementRef;
+	dividerEl: MaybeComputedElementRef;
+}
+
+export const useSizes = (size: Ref<number>, options: UseSizesOptions) => {
+	const { width: componentWidth, height: componentHeight } = useElementSize(options.panelEl);
+	const componentSize = computed(() => toValue(options.orientation) === 'horizontal' ? componentWidth.value : componentHeight.value);
+
+	const { width: dividerWidth, height: dividerHeight } = useElementSize(options.dividerEl);
+	const dividerSize = computed(() => toValue(options.orientation) === 'horizontal' ? dividerWidth.value : dividerHeight.value);
+
+	const sizePercentage = computed({
+		get() {
+			if (toValue(options.sizeUnit) === '%') return size.value;
+			return pixelsToPercentage(componentSize.value, size.value);
+		},
+		set(newValue: number) {
+			if (toValue(options.sizeUnit) === '%') {
+				size.value = newValue;
+			}
+			else {
+				size.value = percentageToPixels(componentSize.value, newValue);
+			}
+		},
+	});
+
+	const sizePixels = computed({
+		get() {
+			if (toValue(options.sizeUnit) === 'px') return size.value;
+			return percentageToPixels(componentSize.value, size.value);
+		},
+		set(newValue: number) {
+			if (toValue(options.sizeUnit) === 'px') {
+				size.value = newValue;
+			}
+			else {
+				size.value = pixelsToPercentage(componentSize.value, newValue);
+			}
+		},
+	});
+
+	const minSizePercentage = computed(() => {
+		if (toValue(options.minSize) === undefined) return;
+
+		if (toValue(options.sizeUnit) === '%') return toValue(options.minSize);
+		return pixelsToPercentage(componentSize.value, toValue(options.minSize));
+	});
+
+	const minSizePixels = computed(() => {
+		if (toValue(options.minSize) === undefined) return;
+
+		if (toValue(options.sizeUnit) === 'px') return toValue(options.minSize);
+		return percentageToPixels(componentSize.value, toValue(options.minSize));
+	});
+
+	const maxSizePercentage = computed(() => {
+		if (toValue(options.maxSize) === undefined) return;
+
+		if (toValue(options.sizeUnit) === '%') return toValue(options.maxSize);
+		return pixelsToPercentage(componentSize.value, toValue(options.maxSize)!);
+	});
+
+	const snapPixels = computed(() => {
+		if (toValue(options.sizeUnit) === 'px') return toValue(options.snapPoints);
+		return toValue(options.snapPoints).map((snapPercentage) => percentageToPixels(componentSize.value, snapPercentage));
+	});
+
+	return {
+		componentSize,
+		dividerSize,
+		sizePercentage,
+		sizePixels,
+		minSizePercentage,
+		minSizePixels,
+		maxSizePercentage,
+		snapPixels,
+	};
+};

--- a/packages/vue-split-panel/src/types.ts
+++ b/packages/vue-split-panel/src/types.ts
@@ -1,18 +1,23 @@
+export type Orientation = 'horizontal' | 'vertical';
+export type Direction = 'ltr' | 'rtl';
+export type Primary = 'start' | 'end';
+export type SizeUnit = '%' | 'px';
+
 export interface SplitPanelProps {
 	/**
 	 * Sets the split panel's orientation
 	 * @default 'horizontal'
 	 */
-	orientation?: 'horizontal' | 'vertical';
+	orientation?: Orientation;
 
 	/**
 	 * Sets the split panel's text direction
 	 * @default 'ltr'
 	 */
-	direction?: 'ltr' | 'rtl';
+	direction?: Direction;
 
 	/** If no primary panel is designated, both panels will resize proportionally when the host element is resized. If a primary panel is designated, it will maintain its size and the other panel will grow or shrink as needed when the panels component is resized */
-	primary?: 'start' | 'end';
+	primary?: Primary | undefined;
 
 	/**
 	 * The invisible region around the divider where dragging can occur. This is usually wider than the divider to facilitate easier dragging. CSS value
@@ -24,7 +29,7 @@ export interface SplitPanelProps {
 	 * Whether the size v-model should be in relative percentages or absolute pixels
 	 * @default '%'
 	 */
-	sizeUnit?: '%' | 'px';
+	sizeUnit?: SizeUnit;
 
 	/**
 	 * Disable the manual resizing of the panels


### PR DESCRIPTION
Easier to keep track of what's happening in the component vs outside, and make it easier to test the logic in isolation