### PR TITLE
fix: allow expand during the same drag event as collapse

### DIFF
--- a/packages/vue-split-panel/playground/src/App.vue
+++ b/packages/vue-split-panel/playground/src/App.vue
@@ -1,9 +1,13 @@
 <script lang="ts" setup>
+import { ref } from 'vue';
 import { SplitPanel } from '../../src';
+
+const size = ref(250);
+const collapsed = ref(false);
 </script>
 
 <template>
-	<SplitPanel id="panels-root" :snap-points="[25, 50]">
+	<SplitPanel id="panels-root" v-model:size="size" v-model:collapsed="collapsed" collapsible :collapse-threshold="100" :min-size="250" :max-size="400" size-unit="px">
 		<template #start>
 			<div id="a" class="panel">
 				Panel A

--- a/packages/vue-split-panel/src/composables/use-pointer.test.ts
+++ b/packages/vue-split-panel/src/composables/use-pointer.test.ts
@@ -1,8 +1,19 @@
+import type { UseDraggableReturn } from '@vueuse/core';
 import type { Ref } from 'vue';
 import type { UsePointerOptions } from './use-pointer';
-import { beforeEach, describe, expect, it } from 'vitest';
-import { computed, ref } from 'vue';
+import { useDraggable } from '@vueuse/core';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { computed, nextTick, ref } from 'vue';
 import { usePointer } from './use-pointer';
+
+vi.mock('@vueuse/core', async () => {
+	const actual = await vi.importActual('@vueuse/core');
+
+	return {
+		...actual,
+		useDraggable: vi.fn(),
+	};
+});
 
 describe('usePointer', () => {
 	let collapsed: Ref<boolean>;
@@ -11,6 +22,10 @@ describe('usePointer', () => {
 	let options: UsePointerOptions;
 	let dividerEl: Ref<HTMLElement | null>;
 	let panelEl: Ref<HTMLElement | null>;
+
+	let mockDragX: Ref<number>;
+	let mockDragY: Ref<number>;
+	let mockDragDragging: Ref<boolean>;
 
 	beforeEach(() => {
 		collapsed = ref(false);
@@ -40,6 +55,12 @@ describe('usePointer', () => {
 			minSizePixels: computed(() => 50),
 			snapPixels: computed(() => [100, 200, 300]),
 		};
+
+		mockDragX = ref(75);
+		mockDragY = ref(75);
+		mockDragDragging = ref(false);
+
+		vi.mocked(useDraggable).mockReturnValue({ x: mockDragX, y: mockDragY, isDragging: mockDragDragging } as UseDraggableReturn);
 	});
 
 	it('should return handleDblClick and isDragging', () => {
@@ -51,51 +72,190 @@ describe('usePointer', () => {
 		expect(typeof result.isDragging.value).toBe('boolean');
 	});
 
-	it('should handle double click to snap to closest point', () => {
-		const { handleDblClick } = usePointer(collapsed, sizePercentage, sizePixels, options);
+	describe('dbl click', () => {
+		it('should handle double click to snap to closest point', () => {
+			const { handleDblClick } = usePointer(collapsed, sizePercentage, sizePixels, options);
 
-		sizePixels.value = 195; // Close to 200
-		handleDblClick();
+			sizePixels.value = 195; // Close to 200
+			handleDblClick();
 
-		expect(sizePixels.value).toBe(200);
+			expect(sizePixels.value).toBe(200);
+		});
+
+		it('should remain collapsed on handle double click when collapsed', () => {
+			collapsed.value = true;
+			const { handleDblClick } = usePointer(collapsed, sizePercentage, sizePixels, options);
+
+			handleDblClick();
+
+			expect(collapsed.value).toBe(true);
+		});
+
+		it('should not snap on double click when disabled', () => {
+			options.disabled = ref(true);
+			const originalSize = sizePixels.value;
+			const { handleDblClick } = usePointer(collapsed, sizePercentage, sizePixels, options);
+
+			handleDblClick();
+
+			expect(sizePixels.value).toBe(originalSize);
+		});
+
+		it('should not snap on double click when no snap points exist', () => {
+			options.snapPixels = computed(() => []);
+			const originalSize = sizePixels.value;
+			const { handleDblClick } = usePointer(collapsed, sizePercentage, sizePixels, options);
+
+			handleDblClick();
+
+			expect(sizePixels.value).toBe(originalSize);
+		});
+
+		it('should handle when collapsible is false', () => {
+			options.collapsible = ref(false);
+			collapsed.value = false;
+			const { handleDblClick } = usePointer(collapsed, sizePercentage, sizePixels, options);
+
+			handleDblClick();
+
+			expect(collapsed.value).toBe(false); // Should remain visible when not collapsible
+		});
 	});
 
-	it('should remain collapsed on handle double click when collapsed', () => {
-		collapsed.value = true;
-		const { handleDblClick } = usePointer(collapsed, sizePercentage, sizePixels, options);
+	describe('dragging', () => {
+		it('should not do anything when disabled', async () => {
+			options.disabled = true;
 
-		handleDblClick();
+			usePointer(collapsed, sizePercentage, sizePixels, options);
 
-		expect(collapsed.value).toBe(true);
-	});
+			mockDragDragging.value = true;
+			mockDragX.value = 30; // below the minsize - threshold
+			await nextTick();
+			expect(collapsed.value).toBe(false);
+		});
 
-	it('should not snap on double click when disabled', () => {
-		options.disabled = ref(true);
-		const originalSize = sizePixels.value;
-		const { handleDblClick } = usePointer(collapsed, sizePercentage, sizePixels, options);
+		it('should update sizePercentage when dragging horizontally', async () => {
+			usePointer(collapsed, sizePercentage, sizePixels, options);
 
-		handleDblClick();
+			mockDragX.value = 100; // Move to 100px
+			await nextTick();
+			expect(sizePercentage.value).toBe(25); // 100/400 * 100 = 25%
+		});
 
-		expect(sizePixels.value).toBe(originalSize);
-	});
+		it('should update sizePercentage when dragging vertically', async () => {
+			options.orientation = ref('vertical');
+			usePointer(collapsed, sizePercentage, sizePixels, options);
 
-	it('should not snap on double click when no snap points exist', () => {
-		options.snapPixels = computed(() => []);
-		const originalSize = sizePixels.value;
-		const { handleDblClick } = usePointer(collapsed, sizePercentage, sizePixels, options);
+			mockDragY.value = 150; // Move to 150px
+			await nextTick();
+			expect(sizePercentage.value).toBe(37.5); // 150/400 * 100 = 37.5%
+		});
 
-		handleDblClick();
+		it('should handle primary end positioning', async () => {
+			options.primary = ref('end');
+			usePointer(collapsed, sizePercentage, sizePixels, options);
 
-		expect(sizePixels.value).toBe(originalSize);
-	});
+			mockDragX.value = 100; // Drag position at 100px
+			await nextTick();
+			// With primary end, actual position = 400 - 100 = 300px
 
-	it('should handle when collapsible is false', () => {
-		options.collapsible = ref(false);
-		collapsed.value = false;
-		const { handleDblClick } = usePointer(collapsed, sizePercentage, sizePixels, options);
+			expect(sizePercentage.value).toBe(75); // 300/400 * 100 = 75%
+		});
 
-		handleDblClick();
+		it('should collapse when dragging below collapse threshold', async () => {
+			options.minSizePixels = computed(() => 50);
+			options.collapseThreshold = ref(10);
+			usePointer(collapsed, sizePercentage, sizePixels, options);
 
-		expect(collapsed.value).toBe(false); // Should remain visible when not collapsible
+			mockDragX.value = 30; // Below minSize (50) - collapseThreshold (10) = 40
+			await nextTick();
+			expect(collapsed.value).toBe(true);
+		});
+
+		it('should expand when dragging above expand threshold', async () => {
+			collapsed.value = true;
+			options.collapseThreshold = ref(15);
+			usePointer(collapsed, sizePercentage, sizePixels, options);
+
+			mockDragX.value = 20; // Above collapseThreshold (15)
+			await nextTick();
+			expect(collapsed.value).toBe(false);
+		});
+
+		it('should not collapse when collapsible is false', async () => {
+			options.collapsible = ref(false);
+			usePointer(collapsed, sizePercentage, sizePixels, options);
+
+			mockDragX.value = 10; // Very low position
+			await nextTick();
+			expect(collapsed.value).toBe(false);
+		});
+
+		it('should snap to snap points within threshold', async () => {
+			options.snapPixels = computed(() => [100, 200, 300]);
+			options.snapThreshold = ref(8);
+			usePointer(collapsed, sizePercentage, sizePixels, options);
+
+			mockDragX.value = 195; // Within 8px of snap point 200
+			await nextTick();
+			expect(sizePercentage.value).toBe(50); // 200/400 * 100 = 50%
+		});
+
+		it('should not snap when outside snap threshold', async () => {
+			options.snapPixels = computed(() => [100, 200, 300]);
+			options.snapThreshold = ref(5);
+			usePointer(collapsed, sizePercentage, sizePixels, options);
+
+			mockDragX.value = 190; // Outside 5px threshold of snap point 200
+			await nextTick();
+			expect(sizePercentage.value).toBe(47.5); // 190/400 * 100 = 47.5%
+		});
+
+		it('should handle RTL direction with horizontal orientation', async () => {
+			options.direction = ref('rtl');
+			options.orientation = ref('horizontal');
+			options.snapPixels = computed(() => [100]);
+			options.snapThreshold = ref(5);
+			usePointer(collapsed, sizePercentage, sizePixels, options);
+
+			// With RTL, snap point 100 becomes 400 - 100 = 300
+			mockDragX.value = 298; // Within threshold of transformed snap point
+			await nextTick();
+			expect(sizePercentage.value).toBe(75); // 300/400 * 100 = 75%
+		});
+
+		it('should clamp sizePercentage between 0 and 100', async () => {
+			usePointer(collapsed, sizePercentage, sizePixels, options);
+
+			mockDragX.value = -50; // Negative position
+			await nextTick();
+			expect(sizePercentage.value).toBe(0);
+
+			mockDragX.value = 500; // Beyond component size
+			await nextTick();
+			expect(sizePercentage.value).toBe(100);
+		});
+
+		it('should update threshold location when dragging stops', async () => {
+			usePointer(collapsed, sizePercentage, sizePixels, options);
+
+			// Start dragging
+			mockDragDragging.value = true;
+			await nextTick();
+
+			// Collapse during drag
+			mockDragX.value = 30;
+			await nextTick();
+			expect(collapsed.value).toBe(true);
+
+			// Stop dragging
+			mockDragDragging.value = false;
+			await nextTick();
+
+			// Should now be in expand mode for next drag
+			mockDragX.value = 5; // Below expand threshold
+			await nextTick();
+			expect(collapsed.value).toBe(true); // Should remain collapsed
+		});
 	});
 });


### PR DESCRIPTION

https://github.com/user-attachments/assets/dcfe4c9d-4789-43c0-abea-7ae755085a11

This interaction now feels a lot better than before