### PR TITLE
feat: Expand on dbl click when collapsed

### DIFF
--- a/packages/vue-split-panel/src/composables/use-pointer.test.ts
+++ b/packages/vue-split-panel/src/composables/use-pointer.test.ts
@@ -82,13 +82,13 @@ describe('usePointer', () => {
 			expect(sizePixels.value).toBe(200);
 		});
 
-		it('should remain collapsed on handle double click when collapsed', () => {
+		it('should expand on double click when collapsed', () => {
 			collapsed.value = true;
 			const { handleDblClick } = usePointer(collapsed, sizePercentage, sizePixels, options);
 
 			handleDblClick();
 
-			expect(collapsed.value).toBe(true);
+			expect(collapsed.value).toBe(false);
 		});
 
 		it('should not snap on double click when disabled', () => {

--- a/packages/vue-split-panel/src/composables/use-pointer.ts
+++ b/packages/vue-split-panel/src/composables/use-pointer.ts
@@ -77,6 +77,10 @@ export const usePointer = (collapsed: Ref<boolean>, sizePercentage: Ref<number>,
 		if (closest !== undefined) {
 			sizePixels.value = closest;
 		}
+
+		if (collapsed.value === true) {
+			collapsed.value = false;
+		}
 	};
 
 	return { handleDblClick, isDragging };


### PR DESCRIPTION
When the primary panel is collapsed, it will now expand when you double click on the closed divider when collapsed.