### PR TITLE
feat(#47): allow min to be used as a floor

### DIFF
--- a/packages/vue-split-panel/src/composables/use-grid-template.test.ts
+++ b/packages/vue-split-panel/src/composables/use-grid-template.test.ts
@@ -40,6 +40,17 @@ describe('useGridTemplate', () => {
 
 		expect(gridTemplate.value).toBe('clamp(0%, clamp(20%, 50%, 80%), calc(100% - 4px)) 4px auto');
 	});
+    
+    it('respects minSizePercentage as a floor when max is not set', () => {
+        const options = createOptions({
+            minSizePercentage: computed(() => 30),
+        });
+        const { gridTemplate } = useGridTemplate(options);
+
+        expect(gridTemplate.value).toBe(
+            'clamp(30%, max(30%, 50%), calc(100% - 4px)) 4px auto'
+        );
+    });
 
 	it('reverses order when primary is end and direction is ltr', () => {
 		const options = createOptions({ primary: 'end' });

--- a/packages/vue-split-panel/src/composables/use-grid-template.ts
+++ b/packages/vue-split-panel/src/composables/use-grid-template.ts
@@ -23,6 +23,9 @@ export const useGridTemplate = (options: UseGridTemplateOptions) => {
 		else if (options.minSizePercentage.value !== undefined && options.maxSizePercentage.value !== undefined) {
 			primary = `clamp(0%, clamp(${options.minSizePercentage.value}%, ${options.sizePercentage.value}%, ${options.maxSizePercentage.value}%), calc(100% - ${options.dividerSize.value}px))`;
 		}
+        else if (options.minSizePercentage.value !== undefined) {
+            primary = `clamp(${options.minSizePercentage.value}%, max(${options.minSizePercentage.value}%, ${options.sizePercentage.value}%), calc(100% - ${options.dividerSize.value}px))`;
+        }
 		else {
 			primary = `clamp(0%, ${options.sizePercentage.value}%, calc(100% - ${options.dividerSize.value}px))`;
 		}


### PR DESCRIPTION
This should solve #47 - which allows `min-size` to be respected and used as a floor when there is no `max-size` set.  In my testing all seems to work well.  I've added a test to the suite, everything still passes.

I haven't added anything to the docs as this doesn't necessarily seem like a feature that needs to be called out, but I'm happy to amend that if needed!

Otherwise, let me know if there's any changes and I can jump on them.  Thanks!