### PR TITLE
fix: guard pixelsToPercentage against zero area

### DIFF
--- a/packages/vue-split-panel/src/utils/pixels-to-percentage.test.ts
+++ b/packages/vue-split-panel/src/utils/pixels-to-percentage.test.ts
@@ -24,6 +24,11 @@ describe("pixelsToPercentage", () => {
 		expect(pixelsToPercentage(1e9, 1e6)).toBeCloseTo(0.1, 6);
 	});
 
+	it("returns 0 when area is 0 (avoids NaN/Infinity on mount)", () => {
+		expect(pixelsToPercentage(0, 0)).toBe(0);
+		expect(pixelsToPercentage(0, 400)).toBe(0);
+	});
+
 	it("does not clamp out-of-range values (negative or > 100%)", () => {
 		expect(pixelsToPercentage(500, -50)).toBe(-10);
 		expect(pixelsToPercentage(500, 750)).toBe(150);

--- a/packages/vue-split-panel/src/utils/pixels-to-percentage.ts
+++ b/packages/vue-split-panel/src/utils/pixels-to-percentage.ts
@@ -4,4 +4,4 @@
  * @param pixels - The pixel value to convert to percentage
  * @returns The percentage value (0-100) that the pixels represent of the total area
  */
-export const pixelsToPercentage = (area: number, pixels: number) => (pixels / area) * 100;
+export const pixelsToPercentage = (area: number, pixels: number) => (area === 0 ? 0 : (pixels / area) * 100);


### PR DESCRIPTION
Returns 0 when area is 0 instead of `NaN`/`Infinity`. This prevents invalid values during component mount before the container has been measured.