### PR TITLE
fix: prevent resize divider from interfering with neighboring scrollbars

### DIFF
--- a/docs/content/1.getting-started/2.usage.md
+++ b/docs/content/1.getting-started/2.usage.md
@@ -69,7 +69,7 @@ If no primary panel is designated, both panels will resize equally.
 
 ::field{name="dividerHitArea" type="string"}
 A CSS size to define the hitbox area around the divider slot.  
- Defaults to `'12px'`
+ Defaults to `'4px'`
 ::
 
 ::field{name="sizeUnit" type="'%' | 'px'"}

--- a/packages/vue-split-panel/src/SplitPanel.vue
+++ b/packages/vue-split-panel/src/SplitPanel.vue
@@ -12,7 +12,7 @@ const props = withDefaults(defineProps<SplitPanelProps>(), {
 	orientation: "horizontal",
 	disabled: false,
 	minSize: 0,
-	dividerHitArea: "12px",
+	dividerHitArea: "4px",
 	sizeUnit: "%",
 	direction: "ltr",
 	collapsible: false,


### PR DESCRIPTION
This PR reduces the resize divider from 12px to 4px. This prevents the resize divider from interfering with neighboring scrollbars, while still providing a large enough hit area to resize the sidebar.

Fixes #68