### PR TITLE
feat: Add drag to toggle prop with tests and documentation updates

### DIFF
--- a/docs/content/1.getting-started/2.usage.md
+++ b/docs/content/1.getting-started/2.usage.md
@@ -97,6 +97,11 @@ Whether to allow the primary panel to be collapsed on enter key on divider or wh
  Defaults to `false`
 ::
 
+::field{name="dragToToggle" type="boolean"}
+Whether dragging beyond the collapse threshold should collapse or expand the primary panel.  
+ Defaults to `true`
+::
+
 ::field{name="collapseThreshold" type="number"}
 How far to drag beyond the minSize to collapse/expand the primary panel.  
  ::
@@ -209,7 +214,9 @@ By setting `sizeUnit` to `px`, the component will use pixel values for `minSize`
 
 By setting `collapsible` to `true`, you can allow the primary panel to be collapsed by either dragging the divider the `collapseThreshold` beyond the `minSize` or using Enter when focussed on the divider.
 
-Both `minSize` and `collapsibleThreshold` have to be defined.
+Set `drag-to-toggle` to `false` to disable collapsing or expanding when dragging beyond the collapse threshold. Enter-key toggling and programmatic collapse or expand still remain available.
+
+Both `minSize` and `collapseThreshold` have to be defined.
 
 ::code-preview
 :example-collapsible

--- a/packages/vue-split-panel/src/SplitPanel.vue
+++ b/packages/vue-split-panel/src/SplitPanel.vue
@@ -16,6 +16,7 @@ const props = withDefaults(defineProps<SplitPanelProps>(), {
 	sizeUnit: "%",
 	direction: "ltr",
 	collapsible: false,
+	dragToToggle: true,
 	collapsedSize: 0,
 	transitionDuration: 0,
 	transitionTimingFunctionCollapse: "cubic-bezier(0.4, 0, 0.6, 1)",
@@ -69,6 +70,7 @@ const { handleKeydown } = useKeyboard(sizePercentage, collapsed, {
 const { isDragging, handleDblClick } = usePointer(collapsed, sizePercentage, sizePixels, {
 	collapseThreshold: () => props.collapseThreshold,
 	collapsible: () => props.collapsible,
+	dragToToggle: () => props.dragToToggle,
 	direction: () => props.direction,
 	disabled: () => props.disabled,
 	orientation: () => props.orientation,

--- a/packages/vue-split-panel/src/composables/use-pointer.test.ts
+++ b/packages/vue-split-panel/src/composables/use-pointer.test.ts
@@ -44,6 +44,7 @@ describe("usePointer", () => {
 		options = {
 			disabled: ref(false),
 			collapsible: ref(true),
+			dragToToggle: ref(true),
 			primary: ref("start"),
 			orientation: ref("horizontal"),
 			direction: ref("ltr"),

--- a/packages/vue-split-panel/src/composables/use-pointer.test.ts
+++ b/packages/vue-split-panel/src/composables/use-pointer.test.ts
@@ -196,6 +196,39 @@ describe("usePointer", () => {
 			expect(collapsed.value).toBe(false);
 		});
 
+		it("should not collapse when dragToToggle is false", async () => {
+			options.dragToToggle = ref(false);
+			usePointer(collapsed, sizePercentage, sizePixels, options);
+
+			mockDragX.value = 30; // Below minSize (50) - collapseThreshold (10) = 40
+			await nextTick();
+
+			expect(collapsed.value).toBe(false);
+		});
+
+		it("should not expand when dragToToggle is false", async () => {
+			collapsed.value = true;
+			options.dragToToggle = ref(false);
+			options.collapseThreshold = ref(15);
+			usePointer(collapsed, sizePercentage, sizePixels, options);
+
+			mockDragX.value = 20; // Above collapseThreshold (15)
+			await nextTick();
+
+			expect(collapsed.value).toBe(true);
+		});
+
+		it("should still update sizePercentage when dragToToggle is false", async () => {
+			options.dragToToggle = ref(false);
+			usePointer(collapsed, sizePercentage, sizePixels, options);
+
+			mockDragX.value = 100;
+			await nextTick();
+
+			expect(collapsed.value).toBe(false);
+			expect(sizePercentage.value).toBe(25);
+		});
+
 		it("should snap to snap points within threshold", async () => {
 			options.snapPixels = computed(() => [100, 200, 300]);
 			options.snapThreshold = ref(8);
@@ -204,6 +237,19 @@ describe("usePointer", () => {
 			mockDragX.value = 195; // Within 8px of snap point 200
 			await nextTick();
 			expect(sizePercentage.value).toBe(50); // 200/400 * 100 = 50%
+		});
+
+		it("should still snap to snap points when dragToToggle is false", async () => {
+			options.dragToToggle = ref(false);
+			options.snapPixels = computed(() => [100, 200, 300]);
+			options.snapThreshold = ref(8);
+			usePointer(collapsed, sizePercentage, sizePixels, options);
+
+			mockDragX.value = 195;
+			await nextTick();
+
+			expect(collapsed.value).toBe(false);
+			expect(sizePercentage.value).toBe(50);
 		});
 
 		it("should not snap when outside snap threshold", async () => {

--- a/packages/vue-split-panel/src/composables/use-pointer.ts
+++ b/packages/vue-split-panel/src/composables/use-pointer.ts
@@ -8,6 +8,7 @@ import { pixelsToPercentage } from "../utils/pixels-to-percentage";
 export interface UsePointerOptions {
 	disabled: MaybeRefOrGetter<boolean>;
 	collapsible: MaybeRefOrGetter<boolean>;
+	dragToToggle: MaybeRefOrGetter<boolean>;
 	primary: MaybeRefOrGetter<Primary | undefined>;
 	orientation: MaybeRefOrGetter<Orientation>;
 	direction: MaybeRefOrGetter<Direction>;
@@ -47,7 +48,11 @@ export const usePointer = (
 			newPositionInPixels = options.componentSize.value - newPositionInPixels;
 		}
 
-		if (toValue(options.collapsible) && toValue(options.collapseThreshold) !== undefined) {
+		if (
+			toValue(options.collapsible) &&
+			toValue(options.dragToToggle) &&
+			toValue(options.collapseThreshold) !== undefined
+		) {
 			let threshold: number;
 
 			if (thresholdLocation === "collapse")

--- a/packages/vue-split-panel/src/types.ts
+++ b/packages/vue-split-panel/src/types.ts
@@ -58,6 +58,12 @@ export interface SplitPanelProps {
 	 */
 	collapsible?: boolean;
 
+	/**
+	 * Whether dragging past the collapse threshold should collapse or expand the primary panel
+	 * @default true
+	 */
+	dragToToggle?: boolean;
+
 	/** How far to drag beyond the minSize to collapse/expand the primary panel */
 	collapseThreshold?: number;
 


### PR DESCRIPTION
This pull request introduces a new `dragToToggle` prop to the `SplitPanel` component, allowing developers to control whether dragging past the collapse threshold will collapse or expand the primary panel. By default, this behavior is enabled, but it can now be disabled for more granular control. The documentation and tests have been updated to reflect this new option.

**Feature: Drag-to-toggle collapsibility**
- Added a new `dragToToggle` boolean prop to `SplitPanel`, defaulting to `true`, which determines if dragging beyond the collapse threshold will trigger collapse/expand actions (`packages/vue-split-panel/src/types.ts`, `packages/vue-split-panel/src/SplitPanel.vue`) [[1]](diffhunk://#diff-c9a2a11a3407c3093c9658a90efa36aec8146c236a75953ce8f137adb1e569feR61-R66) [[2]](diffhunk://#diff-3f561c8b9858c0761a07c2b7d6c7722e0c7c23b9443718c772c9d3b10782a468R19).
- Updated the internal pointer logic to respect the `dragToToggle` prop, so collapsing/expanding on drag only occurs if enabled (`packages/vue-split-panel/src/composables/use-pointer.ts`) [[1]](diffhunk://#diff-a7122878306abe303dbc8c517178b74f0ce4c9c4dce56add4aff6f9820f61346R11) [[2]](diffhunk://#diff-a7122878306abe303dbc8c517178b74f0ce4c9c4dce56add4aff6f9820f61346L50-R55).

**Documentation**
- Documented the new `dragToToggle` prop, including its default value and usage details (`docs/content/1.getting-started/2.usage.md`) [[1]](diffhunk://#diff-bd80eddf8f697b06ea33e896baecbb8d175d1564b23f3af6a0b0270501bd6e68R100-R104) [[2]](diffhunk://#diff-bd80eddf8f697b06ea33e896baecbb8d175d1564b23f3af6a0b0270501bd6e68L212-R219).

**Testing**
- Added and updated tests to verify behavior when `dragToToggle` is `false`, ensuring that drag gestures do not collapse/expand the panel but still update the size and snap to snap points as expected (`packages/vue-split-panel/src/composables/use-pointer.test.ts`) [[1]](diffhunk://#diff-96c24b4d30b75e4289ba971b878024c37937401b1984c5936d5d828ea25eba5cR47) [[2]](diffhunk://#diff-96c24b4d30b75e4289ba971b878024c37937401b1984c5936d5d828ea25eba5cR199-R231) [[3]](diffhunk://#diff-96c24b4d30b75e4289ba971b878024c37937401b1984c5936d5d828ea25eba5cR242-R254).

These changes provide more flexibility for users who want to disable drag-to-collapse behavior while retaining keyboard and programmatic toggling.