### PR TITLE
feat: Improve styling for collapsed non interactive state

### DIFF
--- a/packages/vue-split-panel/src/SplitPanel.vue
+++ b/packages/vue-split-panel/src/SplitPanel.vue
@@ -119,6 +119,7 @@ defineExpose({ collapse, expand, toggle });
 			{
 				'sp-collapsed': collapsed,
 				'sp-dragging': isDragging,
+				'sp-drag-toggle': dragToToggle,
 				[`sp-${collapseTransitionState}`]: collapseTransitionState,
 			},
 		]"
@@ -173,7 +174,7 @@ defineExpose({ collapse, expand, toggle });
 			transition-property: grid-template-columns;
 		}
 
-		&.sp-dragging {
+		&.sp-dragging:is(.sp-drag-toggle, :not(.sp-collapsed)) {
 			cursor: ew-resize;
 		}
 	}
@@ -186,7 +187,7 @@ defineExpose({ collapse, expand, toggle });
 			transition-property: grid-template-rows;
 		}
 
-		&.sp-dragging {
+		&.sp-dragging:is(.sp-drag-toggle, :not(.sp-collapsed)) {
 			cursor: ns-resize;
 		}
 	}
@@ -204,40 +205,38 @@ defineExpose({ collapse, expand, toggle });
 .sp-divider {
 	position: relative;
 	z-index: 1;
+}
 
-	&:not(.disabled) {
-		& :deep(> :first-child) {
-			&::after {
-				content: "";
-				position: absolute;
-			}
-		}
+.sp-root:is(.sp-drag-toggle, :not(.sp-collapsed))
+	.sp-divider:not(.sp-disabled)
+	:deep(> :first-child)::after {
+	content: "";
+	position: absolute;
+}
 
-		&.sp-horizontal {
-			block-size: 100%;
-			inline-size: max-content;
+.sp-root:is(.sp-drag-toggle, :not(.sp-collapsed)) .sp-divider:not(.sp-disabled).sp-horizontal {
+	block-size: 100%;
+	inline-size: max-content;
 
-			& :deep(> :first-child)::after {
-				block-size: 100%;
-				inset-inline-start: calc(v-bind(dividerHitArea) / -2 + v-bind(dividerSize) * 1px / 2);
-				inset-block-start: 0;
-				inline-size: v-bind(dividerHitArea);
-				cursor: ew-resize;
-			}
-		}
+	& :deep(> :first-child)::after {
+		block-size: 100%;
+		inset-inline-start: calc(v-bind(dividerHitArea) / -2 + v-bind(dividerSize) * 1px / 2);
+		inset-block-start: 0;
+		inline-size: v-bind(dividerHitArea);
+		cursor: ew-resize;
+	}
+}
 
-		&.sp-vertical {
-			inline-size: 100%;
-			block-size: max-content;
+.sp-root:is(.sp-drag-toggle, :not(.sp-collapsed)) .sp-divider:not(.sp-disabled).sp-vertical {
+	inline-size: 100%;
+	block-size: max-content;
 
-			& :deep(> :first-child)::after {
-				inline-size: 100%;
-				inset-block-start: calc(v-bind(dividerHitArea) / -2 + v-bind(dividerSize) * 1px / 2);
-				inset-inline-start: 0;
-				block-size: v-bind(dividerHitArea);
-				cursor: ns-resize;
-			}
-		}
+	& :deep(> :first-child)::after {
+		inline-size: 100%;
+		inset-block-start: calc(v-bind(dividerHitArea) / -2 + v-bind(dividerSize) * 1px / 2);
+		inset-inline-start: 0;
+		block-size: v-bind(dividerHitArea);
+		cursor: ns-resize;
 	}
 }
 </style>


### PR DESCRIPTION
This pull request updates the drag-to-toggle functionality and refines the styling logic for the `SplitPanel` component. The main focus is on improving how drag and toggle states are handled and styled, especially for collapsed panels and when toggling via drag. The changes ensure that visual cues and cursor styles are only applied in the correct interaction states.

**Improved drag-to-toggle and collapsed state handling:**

* Added the `sp-drag-toggle` class dynamically based on the `dragToToggle` state, allowing for more precise styling when toggling panels via drag.
* Updated the cursor style logic so that the `ew-resize` and `ns-resize` cursors are only shown when dragging is active and either drag-to-toggle is enabled or the panel is not collapsed. [[1]](diffhunk://#diff-3f561c8b9858c0761a07c2b7d6c7722e0c7c23b9443718c772c9d3b10782a468L176-R177) [[2]](diffhunk://#diff-3f561c8b9858c0761a07c2b7d6c7722e0c7c23b9443718c772c9d3b10782a468L189-R190)

**Refined divider and root styling:**

* Changed the CSS selectors so that divider styling (such as the after pseudo-element and sizing) only applies when the root has either `sp-drag-toggle` or is not collapsed, and the divider is not disabled. This prevents visual artifacts in inappropriate states. [[1]](diffhunk://#diff-3f561c8b9858c0761a07c2b7d6c7722e0c7c23b9443718c772c9d3b10782a468R208-R217) [[2]](diffhunk://#diff-3f561c8b9858c0761a07c2b7d6c7722e0c7c23b9443718c772c9d3b10782a468L229-R230)
* Removed redundant or incorrectly nested CSS, simplifying the style definitions for maintainability.

These changes collectively enhance the user experience by ensuring that drag and toggle interactions behave and appear consistently and intuitively.